### PR TITLE
As a user, I can see the collected data for a single keyword

### DIFF
--- a/lib/crawlexir/search.ex
+++ b/lib/crawlexir/search.ex
@@ -29,7 +29,7 @@ defmodule Crawlexir.Search do
   @doc """
   Gets a single keyword.
 
-  Raises `Ecto.NoResultsError` if the Keyword does not exist.
+  Returns nil if the Keyword does not exist.
 
   ## Examples
 
@@ -141,20 +141,22 @@ defmodule Crawlexir.Search do
   @doc """
   Get a keyword report.
 
+  Raises `Ecto.NoResultsError` if the report does not exist.
+
   ## Examples
 
-      iex> get_keyword_report(keyword_id)
+      iex> get_keyword_report!(keyword_id)
       {:ok, %Report{}}
 
-      iex> get_keyword_report(keyword_id)
-      nil
+      iex> get_keyword_report!(keyword_id)
+      ** (Ecto.NoResultsError)
 
   """
-  def get_keyword_report(keyword_id) do
+  def get_keyword_report!(keyword_id) do
     Report
     |> where(keyword_id: ^keyword_id)
     |> preload(:keyword)
-    |> Repo.one()
+    |> Repo.one!()
   end
 
   @doc """

--- a/lib/crawlexir/search.ex
+++ b/lib/crawlexir/search.ex
@@ -139,7 +139,23 @@ defmodule Crawlexir.Search do
   end
 
   @doc """
-  Get a keyword report.
+  Gets a single report
+
+  Raises `Ecto.NoResultsError` if the report does not exist.
+
+  ## Examples
+
+      iex> get_report!(report_id)
+      {:ok, %Report{}}
+
+      iex> get_report!(report_id)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_report!(id), do: Repo.get!(Report, id)
+
+  @doc """
+  Gets a single report by keyword ID.
 
   Raises `Ecto.NoResultsError` if the report does not exist.
 

--- a/lib/crawlexir_web/controllers/keyword_controller.ex
+++ b/lib/crawlexir_web/controllers/keyword_controller.ex
@@ -1,0 +1,11 @@
+defmodule CrawlexirWeb.KeywordController do
+  use CrawlexirWeb, :controller
+
+  alias Crawlexir.Search
+
+  def show(conn, %{"id" => keyword_id}) do
+    keyword_report = Search.get_keyword_report(keyword_id)
+
+    render(conn, "show.html", keyword_report: keyword_report)
+  end
+end

--- a/lib/crawlexir_web/controllers/keyword_controller.ex
+++ b/lib/crawlexir_web/controllers/keyword_controller.ex
@@ -4,8 +4,7 @@ defmodule CrawlexirWeb.KeywordController do
   alias Crawlexir.Search
 
   def show(conn, %{"id" => keyword_id}) do
-    keyword_report = Search.get_keyword_report(keyword_id)
-
+    keyword_report = Search.get_keyword_report!(keyword_id)
     render(conn, "show.html", keyword_report: keyword_report)
   end
 end

--- a/lib/crawlexir_web/controllers/report_controller.ex
+++ b/lib/crawlexir_web/controllers/report_controller.ex
@@ -1,0 +1,11 @@
+defmodule CrawlexirWeb.ReportController do
+  use CrawlexirWeb, :controller
+
+  alias Crawlexir.Search
+
+  def show(conn, %{"id" => report_id}) do
+    report = Search.get_report!(report_id)
+
+    html(conn, report.html_content)
+  end
+end

--- a/lib/crawlexir_web/router.ex
+++ b/lib/crawlexir_web/router.ex
@@ -41,6 +41,7 @@ defmodule CrawlexirWeb.Router do
     get "/", DashboardController, :index
 
     resources "/keywords", KeywordController, only: [:show]
+    resources "/reports", ReportController, only: [:show]
   end
 
   # Other scopes may use custom stacks.

--- a/lib/crawlexir_web/router.ex
+++ b/lib/crawlexir_web/router.ex
@@ -39,6 +39,8 @@ defmodule CrawlexirWeb.Router do
       singleton: true
 
     get "/", DashboardController, :index
+
+    resources "/keywords", KeywordController, only: [:show]
   end
 
   # Other scopes may use custom stacks.

--- a/lib/crawlexir_web/templates/dashboard/index.html.eex
+++ b/lib/crawlexir_web/templates/dashboard/index.html.eex
@@ -12,7 +12,7 @@
         </tr>
       </thead>
       <tbody>
-        <%= render_many(@keywords, CrawlexirWeb.KeywordView, "keyword.html") %>
+        <%= render_many(@keywords, CrawlexirWeb.KeywordView, "_keyword.html", assigns) %>
       </tbody>
     </table>
   <% else %>

--- a/lib/crawlexir_web/templates/keyword/_keyword.html.eex
+++ b/lib/crawlexir_web/templates/keyword/_keyword.html.eex
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= keyword_text_or_link(@keyword) %></td>
+  <td><%= keyword_text_or_link(@conn, @keyword) %></td>
   <td><%= @keyword.inserted_at %></td>
   <td><%= status_text(@keyword) %></td>
 </tr>

--- a/lib/crawlexir_web/templates/keyword/show.html.eex
+++ b/lib/crawlexir_web/templates/keyword/show.html.eex
@@ -37,4 +37,6 @@
     <dt>Number of links</dt>
     <dd><%= @keyword_report.link_count %></dd>
   </dl>
+
+  <iframe src="<%= Routes.report_path(@conn, :show, @keyword_report.id) %>" frameborder="0" width="100%"></iframe>
 </section>

--- a/lib/crawlexir_web/templates/keyword/show.html.eex
+++ b/lib/crawlexir_web/templates/keyword/show.html.eex
@@ -1,0 +1,40 @@
+<header>
+  <%= link("Back to the list of keywords", to: Routes.dashboard_path(@conn, :index)) %>
+  <h2>Report for "<%= @keyword_report.keyword.keyword %>"</h2>
+  <small>Scraped on <%= @keyword_report.keyword.inserted_at %></small>
+</header>
+<section class="keyword-report">
+  <h3>Advertising Content</h3>
+  <dl>
+    <dt>Number of advertisers</dt>
+    <dd><%= @keyword_report.advertiser_link_count %></dd>
+    <dt>Advertiser Links</dt>
+    <dd>
+      <ul>
+        <%= for link <- @keyword_report.advertiser_url_list do %>
+          <li><a href="<%= link %>"><%= link %></a></li>
+        <% end %>
+      </ul>
+    </dd>
+  </dl>
+
+  <h3>Organic Content</h3>
+  <dl>
+    <dt>Number of results</dt>
+    <dd><%= @keyword_report.organic_link_count %></dd>
+    <dt>Advertiser Links</dt>
+    <dd>
+      <ul>
+        <%= for link <- @keyword_report.organic_url_list do %>
+          <li><a href="<%= link %>"><%= link %></a></li>
+        <% end %>
+      </ul>
+    </dd>
+  </dl>
+
+  <h3>Page Content</h3>
+  <dl>
+    <dt>Number of links</dt>
+    <dd><%= @keyword_report.link_count %></dd>
+  </dl>
+</section>

--- a/lib/crawlexir_web/views/keyword_view.ex
+++ b/lib/crawlexir_web/views/keyword_view.ex
@@ -7,7 +7,7 @@ defmodule CrawlexirWeb.KeywordView do
     link(keyword.keyword, to: Routes.keyword_path(conn, :show, keyword.id))
   end
 
-  def keyword_text_or_link(%Keyword{} = keyword), do: keyword.keyword
+  def keyword_text_or_link(conn, %Keyword{} = keyword), do: keyword.keyword
 
   def status_text(%Keyword{status: :pending}), do: "Pending"
   def status_text(%Keyword{status: :in_progress}), do: "Processing"

--- a/lib/crawlexir_web/views/keyword_view.ex
+++ b/lib/crawlexir_web/views/keyword_view.ex
@@ -3,9 +3,8 @@ defmodule CrawlexirWeb.KeywordView do
 
   alias Crawlexir.Search.Keyword
 
-  def keyword_text_or_link(%Keyword{status: :completed} = keyword) do
-    # TODO: replace with actual keyword report path
-    link(keyword.keyword, to: "#")
+  def keyword_text_or_link(conn, %Keyword{status: :completed} = keyword) do
+    link(keyword.keyword, to: Routes.keyword_path(conn, :show, keyword.id))
   end
 
   def keyword_text_or_link(%Keyword{} = keyword), do: keyword.keyword

--- a/test/crawlexir/search/scraper_worker_test.exs
+++ b/test/crawlexir/search/scraper_worker_test.exs
@@ -15,7 +15,7 @@ defmodule Crawlexir.Search.ScraperWorkerTest do
       ScraperWorker.new(job_attributes) |> Oban.insert()
 
       assert %{success: 1, failure: 0} == Oban.drain_queue(:default)
-      assert %Search.Report{} = Search.get_keyword_report(keyword.id)
+      assert %Search.Report{} = Search.get_keyword_report!(keyword.id)
     end
 
     test "perform/1 update the keyword upon success" do

--- a/test/crawlexir/search_test.exs
+++ b/test/crawlexir/search_test.exs
@@ -99,16 +99,30 @@ defmodule Crawlexir.SearchTest do
       assert parsed_result == {:ok, ["first_keyword", "second_keyword"]}
     end
 
-    test "get_keyword_report!/1 with returns a report with given id" do
+    test "get_report!/1 returns a report with given id" do
+      keyword = KeywordFactory.insert!(:keyword_with_user, keyword: "amazing job")
+      report = ReportFactory.insert!(:report, keyword_id: keyword.id)
+
+      assert %Report{} = Search.get_report!(report.id)
+    end
+
+    test "get_report!/1 with invalid data raises an error" do
+      non_existing_id = 1
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Search.get_report!(non_existing_id)
+      end
+    end
+
+    test "get_keyword_report!/1 returns a report with given keyword id" do
       keyword = KeywordFactory.insert!(:keyword_with_user, keyword: "amazing job")
       ReportFactory.insert!(:report, keyword_id: keyword.id)
 
-      fetched_report = Search.get_keyword_report!(keyword.id)
-
+      assert %Report{} = fetched_report = Search.get_keyword_report!(keyword.id)
       assert fetched_report.keyword.keyword == "amazing job"
     end
 
-    test "get_keyword_report!/1 with invalid data returns nil" do
+    test "get_keyword_report!/1 with invalid data raises an error" do
       non_existing_id = 1
 
       assert_raise Ecto.NoResultsError, fn ->

--- a/test/crawlexir/search_test.exs
+++ b/test/crawlexir/search_test.exs
@@ -99,19 +99,21 @@ defmodule Crawlexir.SearchTest do
       assert parsed_result == {:ok, ["first_keyword", "second_keyword"]}
     end
 
-    test "get_keyword_report/1 with returns a report with given id" do
+    test "get_keyword_report!/1 with returns a report with given id" do
       keyword = KeywordFactory.insert!(:keyword_with_user, keyword: "amazing job")
       ReportFactory.insert!(:report, keyword_id: keyword.id)
 
-      fetched_report = Search.get_keyword_report(keyword.id)
+      fetched_report = Search.get_keyword_report!(keyword.id)
 
       assert fetched_report.keyword.keyword == "amazing job"
     end
 
-    test "get_keyword_report/1 with invalid data returns nil" do
+    test "get_keyword_report!/1 with invalid data returns nil" do
       non_existing_id = 1
 
-      assert Search.get_keyword_report(non_existing_id) == nil
+      assert_raise Ecto.NoResultsError, fn ->
+        Search.get_keyword_report!(non_existing_id)
+      end
     end
 
     test "create_keyword_report/1 with valid data returns a report" do

--- a/test/crawlexir_web/controllers/dashboard_controller_test.exs
+++ b/test/crawlexir_web/controllers/dashboard_controller_test.exs
@@ -4,7 +4,7 @@ defmodule CrawlexirWeb.DashboardControllerTest do
   alias Crawlexir.{UserFactory, KeywordFactory}
 
   describe "GET /" do
-    test "lists all use keywords", %{conn: conn} do
+    test "lists all user keywords", %{conn: conn} do
       user = UserFactory.insert!(:user)
       keyword = KeywordFactory.insert!(:keyword, user_id: user.id)
 

--- a/test/crawlexir_web/controllers/dashboard_controller_test.exs
+++ b/test/crawlexir_web/controllers/dashboard_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule CrawlexirWeb.DashboardControllerTest do
-  use CrawlexirWeb.ConnCase
+  use CrawlexirWeb.ConnCase, async: true
 
   alias Crawlexir.{UserFactory, KeywordFactory}
 

--- a/test/crawlexir_web/controllers/keyword_controller_test.exs
+++ b/test/crawlexir_web/controllers/keyword_controller_test.exs
@@ -1,0 +1,19 @@
+defmodule CrawlexirWeb.KeywordControllerTest do
+  use CrawlexirWeb.ConnCase, async: true
+
+  alias Crawlexir.{KeywordFactory, UserFactory, ReportFactory}
+
+  describe "GET /keywords:id" do
+    test "renders the keyword report", %{conn: conn} do
+      user = UserFactory.insert!(:user)
+      keyword = KeywordFactory.insert!(:keyword, user_id: user.id)
+      ReportFactory.insert!(:report, keyword_id: keyword.id)
+
+      conn =
+        authenticated_conn(user)
+        |> get(Routes.keyword_path(conn, :show, keyword.id))
+
+      assert html_response(conn, 200) =~ "Report for \"#{keyword.keyword}\""
+    end
+  end
+end

--- a/test/crawlexir_web/controllers/keyword_controller_test.exs
+++ b/test/crawlexir_web/controllers/keyword_controller_test.exs
@@ -3,7 +3,7 @@ defmodule CrawlexirWeb.KeywordControllerTest do
 
   alias Crawlexir.{KeywordFactory, UserFactory, ReportFactory}
 
-  describe "GET /keywords:id" do
+  describe "GET /keywords/:id" do
     test "renders the keyword report", %{conn: conn} do
       user = UserFactory.insert!(:user)
       keyword = KeywordFactory.insert!(:keyword, user_id: user.id)

--- a/test/crawlexir_web/views/keyword/keyword_view_test.exs
+++ b/test/crawlexir_web/views/keyword/keyword_view_test.exs
@@ -12,7 +12,8 @@ defmodule CrawlexirWeb.KeywordViewTest do
 
     text_or_link = KeywordView.keyword_text_or_link(conn, keyword)
 
-    assert safe_to_string(text_or_link) == "<a href=\"/keywords/#{keyword.id}\">#{keyword.keyword}</a>"
+    assert safe_to_string(text_or_link) ==
+             "<a href=\"/keywords/#{keyword.id}\">#{keyword.keyword}</a>"
   end
 
   test "keyword_text_or_link/2 returns a link given a non-completed keyword", %{conn: conn} do

--- a/test/crawlexir_web/views/keyword/keyword_view_test.exs
+++ b/test/crawlexir_web/views/keyword/keyword_view_test.exs
@@ -6,19 +6,19 @@ defmodule CrawlexirWeb.KeywordViewTest do
   alias CrawlexirWeb.KeywordView
   alias Crawlexir.KeywordFactory
 
-  test "keyword_text_or_link/1 returns a link given a completed keyword" do
+  test "keyword_text_or_link/2 returns a link given a completed keyword", %{conn: conn} do
     keyword =
       KeywordFactory.insert!(:keyword_with_user, keyword: "amazing job", status: :completed)
 
-    text_or_link = KeywordView.keyword_text_or_link(keyword)
+    text_or_link = KeywordView.keyword_text_or_link(conn, keyword)
 
-    assert safe_to_string(text_or_link) == "<a href=\"#\">#{keyword.keyword}</a>"
+    assert safe_to_string(text_or_link) == "<a href=\"/keywords/#{keyword.id}\">#{keyword.keyword}</a>"
   end
 
-  test "keyword_text_or_link/1 returns a link given a non-completed keyword" do
+  test "keyword_text_or_link/2 returns a link given a non-completed keyword", %{conn: conn} do
     keyword = KeywordFactory.insert!(:keyword_with_user, keyword: "amazing job", status: :pending)
 
-    text_or_link = KeywordView.keyword_text_or_link(keyword)
+    text_or_link = KeywordView.keyword_text_or_link(conn, keyword)
 
     assert text_or_link == keyword.keyword
   end


### PR DESCRIPTION
Closes #18 

## What happened
Implement the keyword details page to view all scraped data.

## Insight
I tried to render in the iframe using data URI but it was in vain as I should have thought about the fact URI has a limit on the number of characters 🤦‍♂ 

Beautifying PR is up next after some tests refactoring and improvements.


## Proof Of Work

![localhost_4000_keywords_49(Laptop with MDPI screen)](https://user-images.githubusercontent.com/696529/78219430-b6206600-74e9-11ea-8c72-575d7daff905.png)